### PR TITLE
Bump bolt

### DIFF
--- a/com.adamcake.Bolt.yml
+++ b/com.adamcake.Bolt.yml
@@ -26,7 +26,7 @@ modules:
         sha256: b9c09ebfdf2cbef10cb43527a90d01f02a7397fd3a504bc8c05c5b78767dec47
       - type: git
         url: https://github.com/Adamcake/Bolt.git
-        commit: d5618a6a36ced7b68dde0a18edb099f9fd4bbc9b 
+        commit: d7397b6466ac7b4b617daa98b8e677aed0fad748 
   - name: openjdk
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Tested latest changes to allow logging into OSRS using a legacy osrs account. 

Verified using RS3 and RuneLite for both legacy and jagex accounts and all worked as expected.